### PR TITLE
Use `gen_server:cast/2` to stop worker processes

### DIFF
--- a/src/gen_server_pool_proxy.erl
+++ b/src/gen_server_pool_proxy.erl
@@ -37,7 +37,7 @@ start_link( MgrPid, ProxyRef, Module, Args, Options ) ->
                          [ MgrPid, ProxyRef, Module, Args ], Options ).
 
 stop( Pid, ProxyRef ) ->
-  gen_server:call( Pid, { ProxyRef, stop } ).
+  gen_server:cast( Pid, { ProxyRef, stop } ).
 
 %%====================================================================
 %% gen_server callbacks
@@ -92,6 +92,10 @@ handle_call( Msg,
       { stop, Reason, state( PState, NewS ) }
   end.
 
+
+handle_cast( { ProxyRef, stop },
+             #state{ proxy_ref = ProxyRef } = PState ) ->
+  { stop, normal, PState };
 
 handle_cast( Msg,
              #state{ manager_pid = MgrPid,


### PR DESCRIPTION
gen_server_pool can die in the following cases:
1. timeout
2. the worker process has gone for some reason
I have seen these cases happening under the high load.
In addition since it's not checking the return value of
`gen_server_pool_proxy:stop/2`, it looks better to use
`gen_server:cast/2`.
